### PR TITLE
Added "get_fock"

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ of problematic spin contamination, the CUHF reference may be used to form a spin
 UHF solution. 
 
 ### Naming
-It is customary for Julia modules and data structures to have CamelCase names, such as `Wavefunction.jl`. Please follow this aesthetically pleasing convention! 
+It is customary for Julia modules and data structures to have CamelCase names, such as `CoupledCluster.jl`. Please follow this aesthetically pleasing convention! 
 
 ## Submodules
 This section contains a description of some preliminary modules in the JuES environment. Many aspects are aspirational, and the description is not so much a description of current functionality as a statement of intent.

--- a/src/Backend/IntegralTransformation.jl
+++ b/src/Backend/IntegralTransformation.jl
@@ -3,6 +3,7 @@ using TensorOperations
 using JuES.Wavefunction
 
 export get_eri
+export get_fock
 
 """
     get_eri 
@@ -22,7 +23,7 @@ function get_eri(wfn::Wfn, eri_string::String, notation::String = "phys")
 
     # Size of eri_string must be 4.
     if sizeof(eri_string) != 4
-        error("Invalid string given to JuES.Integrals.get_eri: $eri_string")
+        error("Invalid string given to JuES.IntegralTransformation.get_eri: $eri_string")
     end
 
     # The computations below assumed Chemist's notation. Thus, the string is modified if Phys is requested
@@ -53,6 +54,42 @@ function get_eri(wfn::Wfn, eri_string::String, notation::String = "phys")
     end
 
     return V
+end
+
+"""
+    get_fock
+
+return a specified spin case of the Fock matrix.
+
+Arguments:
+
+wfn  -> Wavefunction object
+spin -> OPTIONAL. String indicated which spin the Fock matrix has. Accept: "alpha", "a" or "up" for alpha arrays and "Beta", "b", "down" for beta arrays.
+        Case insensitive. 
+
+"""
+function get_fock(wfn::Wfn, spin::String = "alpha")
+
+    if lowercase(spin) in ["alpha", "up", "a"]
+        C  = wfn.Ca
+        Co = wfn.Cao
+    elseif lowercase(spin) in ["beta", "down", "b"]
+        C  = wfn.Cb
+        Co = wfn.Cbo
+    else
+        error("Invalid Spin option given to JuES.IntegralTransformation.get_fock: $spin")
+    end
+
+    gao = wfn.ao_eri
+    hao = wfn.hao
+
+    @tensoropt (p=>100x, q=>100x, k=>x, μ=>100x, ν=>100x, λ=>100x, σ=>100x) begin
+        f[p,q] := C[μ,p]*C[ν,q]*hao[μ,ν] 
+        f[p,q] += 2*C[μ,p]*C[ν,q]*Co[λ,k]*Co[σ,k]*gao[μ,ν,λ,σ]
+        f[p,q] -= C[μ,p]*C[ν,q]*Co[λ,k]*Co[σ,k]*gao[μ,λ,ν,σ]
+    end
+
+    return f
 end
 
 end # Module


### PR DESCRIPTION
1. Coded up `get_fock` function into `IntegralTransformation`. It produces a full fock matrix for non HF CC computations;

2. Adapted `unf-CCSD.jl` to use `get_fock`;

3. Changed `README.md` on the camelcase example. Just a suggestion, I think `CoupledCluster.jl` better illustrates your point. 
